### PR TITLE
added writer draining (w/ deadline) to Writer.Stop()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Psiphon-Inc/uds-ipc
 
-go 1.24.4
+go 1.24.0

--- a/integration_test.go
+++ b/integration_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package udsipc
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -140,7 +141,7 @@ func TestReaderWriterIntegration(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewWriter() error = %v", err)
 			}
-			defer writer.Stop()
+			defer writer.Stop(context.Background())
 
 			// Start reader first
 			if err := reader.Start(); err != nil {
@@ -264,7 +265,7 @@ func TestReaderWriterConnectionRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewWriter() error = %v", err)
 	}
-	defer writer.Stop()
+	defer writer.Stop(context.Background())
 
 	// Start writer first (will fail to connect initially)
 	writer.Start()
@@ -382,7 +383,7 @@ func TestReaderWriterConcurrentSenders(t *testing.T) {
 				t.Errorf("NewWriter() error = %v", err)
 				return
 			}
-			defer writer.Stop()
+			defer writer.Stop(context.Background())
 
 			writer.Start()
 
@@ -479,7 +480,7 @@ func TestReaderWriterHandlerError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewWriter() error = %v", err)
 	}
-	defer writer.Stop()
+	defer writer.Stop(context.Background())
 
 	if err := reader.Start(); err != nil {
 		t.Fatalf("reader.Start() error = %v", err)

--- a/performance_bench_test.go
+++ b/performance_bench_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package udsipc
 
 import (
+	"context"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -47,7 +48,7 @@ func BenchmarkBasicThroughput(b *testing.B) {
 	if err != nil {
 		b.Fatalf("NewWriter() error = %v", err)
 	}
-	defer writer.Stop()
+	defer writer.Stop(context.Background())
 
 	if err := reader.Start(); err != nil {
 		b.Fatalf("reader.Start() error = %v", err)
@@ -115,7 +116,7 @@ func BenchmarkMessageSizes(b *testing.B) {
 			if err != nil {
 				b.Fatalf("NewWriter() error = %v", err)
 			}
-			defer writer.Stop()
+			defer writer.Stop(context.Background())
 
 			if err := reader.Start(); err != nil {
 				b.Fatalf("reader.Start() error = %v", err)
@@ -194,7 +195,7 @@ func BenchmarkBufferOptimization(b *testing.B) {
 			if err != nil {
 				b.Fatalf("NewWriter() error = %v", err)
 			}
-			defer writer.Stop()
+			defer writer.Stop(context.Background())
 
 			if err := reader.Start(); err != nil {
 				b.Fatalf("reader.Start() error = %v", err)
@@ -266,7 +267,7 @@ func BenchmarkMultipleWriters(b *testing.B) {
 					b.Fatalf("NewWriter() error = %v", err)
 				}
 				writers[i] = writer
-				defer writer.Stop()
+				defer writer.Stop(context.Background())
 			}
 
 			if err := reader.Start(); err != nil {
@@ -326,7 +327,7 @@ func BenchmarkWriteOnly(b *testing.B) {
 	if err != nil {
 		b.Fatalf("NewWriter() error = %v", err)
 	}
-	defer writer.Stop()
+	defer writer.Stop(context.Background())
 
 	if err := reader.Start(); err != nil {
 		b.Fatalf("reader.Start() error = %v", err)
@@ -385,7 +386,7 @@ func BenchmarkReadOnly(b *testing.B) {
 	if err != nil {
 		b.Fatalf("NewWriter() error = %v", err)
 	}
-	defer writer.Stop()
+	defer writer.Stop(context.Background())
 
 	if err := reader.Start(); err != nil {
 		b.Fatalf("reader.Start() error = %v", err)

--- a/utils_test.go
+++ b/utils_test.go
@@ -16,8 +16,13 @@ limitations under the License.
 package udsipc
 
 import (
+	"bytes"
+	"context"
+	"log/slog"
 	"os"
 	"runtime"
+	"strings"
+	"testing"
 )
 
 // Copyright 2019 The Go Authors. All rights reserved.
@@ -40,4 +45,195 @@ func LocalPath() (string, error) {
 	f.Close()
 	os.Remove(path)
 	return path, nil
+}
+
+func TestLogEnvironment(t *testing.T) {
+	t.Run("standalone mode", func(t *testing.T) {
+		// Create a buffer to capture log output
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+
+		// Create systemd manager (should detect no systemd environment)
+		systemdManager, err := NewSystemdManager()
+		if err != nil {
+			t.Fatalf("NewSystemdManager() error = %v", err)
+		}
+		defer systemdManager.Close()
+
+		// Call the function under test
+		LogEnvironment(context.Background(), logger, systemdManager, "/test/socket")
+
+		// Check the log output contains expected messages
+		logOutput := buf.String()
+		expectedMessages := []string{"socket_path=/test/socket"}
+
+		for _, expected := range expectedMessages {
+			if !strings.Contains(logOutput, expected) {
+				t.Errorf("expected log to contain %q, but got: %s", expected, logOutput)
+			}
+		}
+
+		// Should contain either "running standalone" OR "running under systemd"
+		if !strings.Contains(logOutput, "running standalone") && !strings.Contains(logOutput, "running under systemd") {
+			t.Errorf("expected log to contain either 'running standalone' or 'running under systemd', but got: %s", logOutput)
+		}
+	})
+}
+
+func TestEnsureSocketDirErrorHandling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		socketPath string
+		setup      func() string // Returns path to test, may modify filesystem
+		cleanup    func(string)  // Cleanup after test
+		wantErr    bool
+	}{
+		{
+			name:       "success_case",
+			socketPath: "/tmp/test-socket-dir/test.sock",
+			setup:      func() string { return "/tmp/test-socket-dir/test.sock" },
+			cleanup:    func(path string) { os.RemoveAll("/tmp/test-socket-dir") },
+			wantErr:    false,
+		},
+		{
+			name: "permission_denied",
+			setup: func() string {
+				// Try to create directory under a read-only parent
+				// This may not work on all systems, so we'll use a more reliable approach
+				if os.Getuid() == 0 { // Skip if running as root
+					return ""
+				}
+				// Create a directory and make it read-only
+				testDir := "/tmp/readonly-test-dir"
+				os.Mkdir(testDir, 0755)
+				os.Chmod(testDir, 0444) // Read-only
+				return testDir + "/subdir/test.sock"
+			},
+			cleanup: func(path string) {
+				if path != "" {
+					os.Chmod("/tmp/readonly-test-dir", 0755) // Restore permissions
+					os.RemoveAll("/tmp/readonly-test-dir")
+				}
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				testPath := tt.setup()
+				if testPath == "" {
+					t.Skip("test setup failed or not applicable")
+				}
+				if tt.cleanup != nil {
+					defer tt.cleanup(testPath)
+				}
+				tt.socketPath = testPath
+			}
+
+			err := EnsureSocketDir(tt.socketPath)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestCleanupSocketErrorHandling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		setup      func() string // Returns path to test
+		cleanup    func(string)  // Cleanup after test
+		wantErr    bool
+	}{
+		{
+			name: "file_exists",
+			setup: func() string {
+				f, err := os.CreateTemp("", "test-socket-cleanup-*")
+				if err != nil {
+					return ""
+				}
+				path := f.Name()
+				f.Close()
+				return path
+			},
+			wantErr: false,
+		},
+		{
+			name: "file_does_not_exist",
+			setup: func() string {
+				return "/tmp/non-existent-socket-file.sock"
+			},
+			wantErr: false, // Should not error for non-existent files
+		},
+		{
+			name: "permission_denied",
+			setup: func() string {
+				if os.Getuid() == 0 { // Skip if running as root
+					return ""
+				}
+				// Create a file in a directory, then make directory read-only
+				dir := "/tmp/readonly-socket-dir"
+				os.Mkdir(dir, 0755)
+
+				f, err := os.Create(dir + "/test.sock")
+				if err != nil {
+					os.RemoveAll(dir)
+					return ""
+				}
+				f.Close()
+
+				os.Chmod(dir, 0444) // Make directory read-only
+				return dir + "/test.sock"
+			},
+			cleanup: func(path string) {
+				if path != "" {
+					dir := "/tmp/readonly-socket-dir"
+					os.Chmod(dir, 0755) // Restore permissions
+					os.RemoveAll(dir)
+				}
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				testPath := tt.setup()
+				if testPath == "" {
+					t.Skip("test setup failed or not applicable")
+				}
+				if tt.cleanup != nil {
+					defer tt.cleanup(testPath)
+				}
+
+				err := CleanupSocket(testPath)
+
+				if tt.wantErr {
+					if err == nil {
+						t.Error("expected error but got nil")
+					}
+				} else {
+					if err != nil {
+						t.Errorf("unexpected error: %v", err)
+					}
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
- added new tests
- refactored tests to use context blocking instead of sleeps wherever possible
- refactored slower benchmarks to cap maximum iterations to preserve reasonable runtimes