### PR TITLE
Buffer failed message and reconnect on write failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ writer, err := udsipc.NewWriter(
 - **Message buffer pooling**: Reuses 4KB buffers to eliminate allocations for small messages
 - **BufIO reader pooling**: Reuses buffered readers across connections
 - **Vectored I/O buffer pooling**: Reuses net.Buffers slices for write operations
-- **Write retry logic**: Single retry on write failure to avoid full reconnect cycles
+- **Write retry logic**: Failed writes are buffered and retried on reconnect, blocking new writes until successful
 - **Socket buffer tuning**: Configurable kernel buffers to optimize network performance
 
 ### Benchmark Results

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -131,8 +131,8 @@ func BenchmarkHandlerLatency(b *testing.B) {
 		messageSize  int
 		maxOps       int // Limit operations for delay benchmarks to prevent timeouts
 	}{
-		{"NoDelay_1KB", 0, 1024, 0}, // 0 means no limit, use b.N
-		{"10us_1KB", 10 * time.Microsecond, 1024, 10000}, // Limit to 10k ops (100ms)
+		{"NoDelay_1KB", 0, 1024, 0},                       // 0 means no limit, use b.N
+		{"10us_1KB", 10 * time.Microsecond, 1024, 10000},  // Limit to 10k ops (100ms)
 		{"100us_1KB", 100 * time.Microsecond, 1024, 1000}, // Limit to 1k ops (100ms)
 	}
 

--- a/reader_test.go
+++ b/reader_test.go
@@ -705,11 +705,11 @@ func TestReaderAcceptErrorHandling(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                    string
-		maxAcceptErrors         int
-		simulatedFailures       int
-		expectTooManyCallback   bool
-		expectEarlyReturn       bool
+		name                  string
+		maxAcceptErrors       int
+		simulatedFailures     int
+		expectTooManyCallback bool
+		expectEarlyReturn     bool
 	}{
 		{
 			name:                  "below_threshold",

--- a/utils_test.go
+++ b/utils_test.go
@@ -155,10 +155,10 @@ func TestCleanupSocketErrorHandling(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		setup      func() string // Returns path to test
-		cleanup    func(string)  // Cleanup after test
-		wantErr    bool
+		name    string
+		setup   func() string // Returns path to test
+		cleanup func(string)  // Cleanup after test
+		wantErr bool
 	}{
 		{
 			name: "file_exists",


### PR DESCRIPTION
The old logic did this:
 
  1. Ensure connection
  2. Attempt to write
  3. On failure, attempt to write again immediately
  4. On failure, drop message, attempt reconnect
  5. Resume normal processing

The new logic does this:

  1. Ensure connection
  2. Attempt to write
  3. On failure, buffer failed message, attempt reconnect
  4. Attempt to write buffered message
  5. On failure, go to 3; on success, continue
  6. Resume normal processing